### PR TITLE
Added Dockerfile and entrypoint script to configure API Urls

### DIFF
--- a/40-env-update.sh
+++ b/40-env-update.sh
@@ -1,0 +1,21 @@
+
+#! /bin/bash
+
+if [ -z "$API_URL" ]
+
+then
+  echo No API Environment Variable Set. Set "-e API_URL='your-server.tld'" in your Docker Config
+else
+  if [ -f /api_set ]
+  then
+    echo API URL Already set to $API_URL
+  else
+    echo Setting API URL to: $API_URL
+    sed -i "s#var apiUrl = defaultUrl#const apiUrl = '$API_URL'#" /usr/share/nginx/html/js/ide.js
+  
+    echo Disabling messages from public Judge CE API
+    sed -i "s^loadMessages();^^1" /usr/share/nginx/html/js/ide.js
+    
+    touch /api_set
+  fi
+fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM nginx
+ADD 40-env-update.sh /docker-entrypoint.d
+RUN chmod +x /docker-entrypoint.d/40-env-update.sh
+COPY . /usr/share/nginx/html
+


### PR DESCRIPTION
I've created a basic Dockerfile that will allow people that are self-hosting the API to also spin up the IDE easily and configure the API URL setting by specifying an environment variable called `API_URL`

Build the image:
```docker build -t judge0-ide .```

Run Locally:
```docker run -d -p 8080:80 --name judge0-ide -e API_URL="https://api.example.com" judge0-ide```

